### PR TITLE
better error message for 403s

### DIFF
--- a/lib/cell/ChainedBatch.js
+++ b/lib/cell/ChainedBatch.js
@@ -74,6 +74,9 @@ export default class ChainedBatch extends AbstractChainedBatch {
       }
 
       let onresponse = res => {
+        if (res.statusCode >= 300) {
+          return cb(new Error(`HTTP error! ${res.statusCode} ${res.statusMessage}`));
+        }
         let reasons = []
 
         let ondata = data => {

--- a/lib/cell/Iterator.js
+++ b/lib/cell/Iterator.js
@@ -71,6 +71,9 @@ export default class Iterator extends AbstractIterator {
       }
 
       get(options, res => {
+        if (res.statusCode >= 300) {
+          return cb(new Error(`HTTP error! ${res.statusCode} ${res.statusMessage}`));
+        }
         this._stream = res.pipe(new FeedParser)
 
         this._stream.on("readable", () => {


### PR DESCRIPTION
I couldn't figure out how to set up my credentials/pems/whatsits, but this should at least provide a more helpful error message if anyone else runs into this.

Before this fix, you'll see:

```
Error: Not a feed
    at FeedParser.handleEnd (/private/tmp/dsfljfsdjlk/node_modules/sheet-down/node_modules/feedparser/main.js:123:13)
    ... long stack trace ...
```

After this fix, you'll see:

```
Error: HTTP error! 403 Forbidden
    at ClientRequest.<anonymous> (/Users/nolan/workspace/sheet-down/dist/cell/Iterator.js:123:25)
    ...
```

BTW, I'm trying to run the example as shown in the README. Got a p12 file from the Google Developers Console, converted it to a PEM file with openssl, put in my service account email and the `sheetId/worksheetId` as shown, but no dice.
