### PR TITLE
Fix import misnomer, lock down dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "abstract-stream-leveldown": "*",
+    "abstract-stream-leveldown": "^1.1.1",
     "google-worksheet-stream": "^1.1.1"
   },
   "devDependencies": {

--- a/sheet-down.js
+++ b/sheet-down.js
@@ -1,6 +1,6 @@
 import {Transform} from "stream"
 import Worksheet from "google-worksheet-stream"
-import {LevelDOWN} from "abstract-stream-leveldown"
+import {AbstractStreamLevelDOWN as LevelDOWN} from "abstract-stream-leveldown"
 
 const keyEncoding = {
   name: "UInt32BE",


### PR DESCRIPTION
There was an import statement looking for a "LevelDOWN" property on `module.exports`, but it had been changed in subsequent versions to "AbstractStreamLevelDOWN". This has been modified to look for the correct property and import it under the old name.

The reason the breaking change made it through was from a loosely defined dependency (abstract-stream). It was always installing the latest version, regardless of version/breaking changes. It has since been locked down to a specific minor version.

Fixes issue #6
